### PR TITLE
fix: opimized keys method

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+#tests
+test
+coverage
+
+#build tools
+.travis.yml
+.jenkins.yml
+.codeclimate.yml
+
+#linters
+.jscsrc
+.jshintrc
+.eslintrc*
+
+#editor settings
+.idea
+.editorconfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qkudev/storage-ns",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qkudev/storage-ns",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "private": false,
   "files": [
     "dist",
     "src"
@@ -10,6 +11,10 @@
   "engines": {
     "node": ">=10"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "sideEffects": false,
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,19 @@ export class StorageNS implements Storage {
     if (i < 0) {
       throw new Error('Key index must be greater or equal to zero');
     }
+    let iter = this.keys();
+    let curr = iter.next();
+    let j = 0;
+    while (j < i && !curr.done) {
+      curr = iter.next();
+      j++;
+    }
 
-    return [...this.keys()][i] || null;
+    if (curr.value === undefined) {
+      return null;
+    }
+
+    return curr.value;
   };
 
   /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,12 +57,15 @@ describe('StorageNS', () => {
 
   it('should return keys by indexes', () => {
     s.setItem('foo', 'bar');
+    s.setItem('bar', 'buzz');
+    s.setItem('buzz', 'foo');
 
-    const key = s.key(0);
-    expect(key).toEqual('foo');
-    expect(s.length).toEqual(1);
+    expect(s.key(0)).toEqual('foo');
+    expect(s.key(1)).toEqual('bar');
+    expect(s.key(2)).toEqual('buzz');
+    expect(s.length).toEqual(3);
 
-    expect(s.key(1)).toEqual(null);
+    expect(s.key(3)).toEqual(null);
   });
 
   it('should throw error on incorrect index', () => {


### PR DESCRIPTION
## Changes

Optimized `keys()` method. Now it won't calculate all keys for any index.